### PR TITLE
Add an action system

### DIFF
--- a/src/main/java/uk/firedev/daisylib/actions/ActionContext.java
+++ b/src/main/java/uk/firedev/daisylib/actions/ActionContext.java
@@ -1,0 +1,48 @@
+package uk.firedev.daisylib.actions;
+
+import org.bukkit.Location;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.Nullable;
+
+public class ActionContext {
+
+    private Player player;
+    private Block block;
+    private Entity affectedEntity;
+
+    private ActionContext() {}
+
+    public static ActionContext create() {
+        return new ActionContext();
+    }
+
+    public ActionContext withPlayer(@Nullable Player player) {
+        this.player = player;
+        return this;
+    }
+
+    public @Nullable Player getPlayer() {
+        return player;
+    }
+
+    public ActionContext withBlock(@Nullable Block block) {
+        this.block = block;
+        return this;
+    }
+
+    public @Nullable Block getBlock() {
+        return block;
+    }
+
+    public ActionContext withEntity(@Nullable Entity affectedEntity) {
+        this.affectedEntity = affectedEntity;
+        return this;
+    }
+
+    public @Nullable Entity getEntity() {
+        return affectedEntity;
+    }
+
+}

--- a/src/main/java/uk/firedev/daisylib/actions/ActionContext.java
+++ b/src/main/java/uk/firedev/daisylib/actions/ActionContext.java
@@ -36,12 +36,12 @@ public class ActionContext {
         return block;
     }
 
-    public ActionContext withEntity(@Nullable Entity affectedEntity) {
+    public ActionContext withAffectedEntity(@Nullable Entity affectedEntity) {
         this.affectedEntity = affectedEntity;
         return this;
     }
 
-    public @Nullable Entity getEntity() {
+    public @Nullable Entity getAffectedEntity() {
         return affectedEntity;
     }
 

--- a/src/main/java/uk/firedev/daisylib/actions/ActionContext.java
+++ b/src/main/java/uk/firedev/daisylib/actions/ActionContext.java
@@ -2,10 +2,13 @@ package uk.firedev.daisylib.actions;
 
 import org.bukkit.Location;
 import org.bukkit.block.Block;
+import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.Map;
 
 public class ActionContext {
 
@@ -13,6 +16,7 @@ public class ActionContext {
     private Block block;
     private Entity affectedEntity;
     private ItemStack item;
+    private Map<Enchantment, Integer> enchantments;
 
     private ActionContext() {}
 
@@ -54,6 +58,15 @@ public class ActionContext {
 
     public @Nullable ItemStack getItem() {
         return item;
+    }
+
+    public ActionContext withEnchantments(@Nullable Map<Enchantment, Integer> enchantments) {
+        this.enchantments = enchantments;
+        return this;
+    }
+
+    public @Nullable Map<Enchantment, Integer> getEnchantments() {
+        return enchantments;
     }
 
 }

--- a/src/main/java/uk/firedev/daisylib/actions/ActionContext.java
+++ b/src/main/java/uk/firedev/daisylib/actions/ActionContext.java
@@ -4,6 +4,7 @@ import org.bukkit.Location;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.Nullable;
 
 public class ActionContext {
@@ -11,6 +12,7 @@ public class ActionContext {
     private Player player;
     private Block block;
     private Entity affectedEntity;
+    private ItemStack item;
 
     private ActionContext() {}
 
@@ -43,6 +45,15 @@ public class ActionContext {
 
     public @Nullable Entity getAffectedEntity() {
         return affectedEntity;
+    }
+
+    public ActionContext withItem(@Nullable ItemStack item) {
+        this.item = item;
+        return this;
+    }
+
+    public @Nullable ItemStack getItem() {
+        return item;
     }
 
 }

--- a/src/main/java/uk/firedev/daisylib/actions/ActionListener.java
+++ b/src/main/java/uk/firedev/daisylib/actions/ActionListener.java
@@ -1,5 +1,6 @@
 package uk.firedev.daisylib.actions;
 
+import org.bukkit.event.EventHandler;
 import org.jetbrains.annotations.NotNull;
 
 public abstract class ActionListener {

--- a/src/main/java/uk/firedev/daisylib/actions/ActionListener.java
+++ b/src/main/java/uk/firedev/daisylib/actions/ActionListener.java
@@ -1,0 +1,13 @@
+package uk.firedev.daisylib.actions;
+
+import org.jetbrains.annotations.NotNull;
+
+public abstract class ActionListener {
+
+    abstract void accept(@NotNull ActionContext context);
+
+    public boolean register(@NotNull String actionName) {
+        return ActionManager.getInstance().registerListener(actionName, this);
+    }
+
+}

--- a/src/main/java/uk/firedev/daisylib/actions/ActionManager.java
+++ b/src/main/java/uk/firedev/daisylib/actions/ActionManager.java
@@ -1,0 +1,48 @@
+package uk.firedev.daisylib.actions;
+
+import org.jetbrains.annotations.NotNull;
+import uk.firedev.daisylib.local.DaisyLib;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.TreeMap;
+
+public class ActionManager {
+
+    private static ActionManager instance = null;
+
+    private final TreeMap<String, ArrayList<ActionListener>> listenerMap;
+
+    private ActionManager() {
+        listenerMap = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+    }
+
+    public static ActionManager getInstance() {
+        if (instance == null) {
+            instance = new ActionManager();
+        }
+        return instance;
+    }
+
+    public boolean registerListener(@NotNull String actionName, @NotNull ActionListener listener) {
+        List<ActionListener> listeners = getListeners(actionName);
+        if (listeners.contains(listener)) {
+            return false;
+        }
+        listeners.add(listener);
+        return true;
+    }
+
+    public void fire(@NotNull String actionName, @NotNull ActionContext context) {
+        List<ActionListener> listeners = getListeners(actionName);
+        if (listeners.isEmpty()) {
+            return;
+        }
+        listeners.forEach(listener -> listener.accept(context));
+    }
+
+    private @NotNull ArrayList<ActionListener> getListeners(@NotNull String actionName) {
+        return listenerMap.computeIfAbsent(actionName, k -> new ArrayList<>());
+    }
+
+}

--- a/src/main/java/uk/firedev/daisylib/actions/ActionManager.java
+++ b/src/main/java/uk/firedev/daisylib/actions/ActionManager.java
@@ -1,6 +1,7 @@
 package uk.firedev.daisylib.actions;
 
 import org.jetbrains.annotations.NotNull;
+import uk.firedev.daisylib.actions.types.BreakActionType;
 import uk.firedev.daisylib.local.DaisyLib;
 
 import java.util.ArrayList;
@@ -11,6 +12,7 @@ public class ActionManager {
 
     private static ActionManager instance = null;
 
+    private boolean loaded = false;
     private final TreeMap<String, ArrayList<ActionListener>> listenerMap;
 
     private ActionManager() {
@@ -22,6 +24,17 @@ public class ActionManager {
             instance = new ActionManager();
         }
         return instance;
+    }
+
+    public void load() {
+        if (isLoaded()) {
+            return;
+        }
+        new BreakActionType().register(DaisyLib.getInstance());
+    }
+
+    public boolean isLoaded() {
+        return loaded;
     }
 
     public boolean registerListener(@NotNull String actionName, @NotNull ActionListener listener) {

--- a/src/main/java/uk/firedev/daisylib/actions/ActionType.java
+++ b/src/main/java/uk/firedev/daisylib/actions/ActionType.java
@@ -11,7 +11,7 @@ public abstract class ActionType implements Listener {
         Bukkit.getPluginManager().registerEvents(this, plugin);
     }
 
-    abstract @NotNull String getActionIdentifier();
+    public abstract @NotNull String getActionIdentifier();
 
     public void fire(@NotNull ActionContext context) {
         ActionManager.getInstance().fire(getActionIdentifier(), context);

--- a/src/main/java/uk/firedev/daisylib/actions/ActionType.java
+++ b/src/main/java/uk/firedev/daisylib/actions/ActionType.java
@@ -1,0 +1,36 @@
+package uk.firedev.daisylib.actions;
+
+import org.bukkit.Bukkit;
+import org.bukkit.event.Listener;
+import org.bukkit.plugin.Plugin;
+import org.jetbrains.annotations.NotNull;
+
+public abstract class ActionType implements Listener {
+
+    public void register(@NotNull Plugin plugin) {
+        Bukkit.getPluginManager().registerEvents(this, plugin);
+    }
+
+    abstract @NotNull String getActionIdentifier();
+
+    public void fire(@NotNull ActionContext context) {
+        ActionManager.getInstance().fire(getActionIdentifier(), context);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof ActionType cast)) {
+            return false;
+        }
+        return getActionIdentifier().equalsIgnoreCase(cast.getActionIdentifier());
+    }
+
+    @Override
+    public int hashCode() {
+        return getActionIdentifier().toLowerCase().hashCode();
+    }
+
+}

--- a/src/main/java/uk/firedev/daisylib/actions/types/BreakActionType.java
+++ b/src/main/java/uk/firedev/daisylib/actions/types/BreakActionType.java
@@ -1,0 +1,26 @@
+package uk.firedev.daisylib.actions.types;
+
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.block.BlockBreakEvent;
+import org.jetbrains.annotations.NotNull;
+import uk.firedev.daisylib.actions.ActionContext;
+import uk.firedev.daisylib.actions.ActionType;
+
+public class BreakActionType extends ActionType {
+
+    @NotNull
+    @Override
+    public String getActionIdentifier() {
+        return "break";
+    }
+
+    @EventHandler
+    public void onBreakBlock(BlockBreakEvent event) {
+        fire(ActionContext.create()
+                .withPlayer(event.getPlayer())
+                .withBlock(event.getBlock())
+                .withAffectedEntity(event.getPlayer())
+        );
+    }
+
+}

--- a/src/main/java/uk/firedev/daisylib/actions/types/BreakActionType.java
+++ b/src/main/java/uk/firedev/daisylib/actions/types/BreakActionType.java
@@ -1,6 +1,7 @@
 package uk.firedev.daisylib.actions.types;
 
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.block.BlockBreakEvent;
 import org.jetbrains.annotations.NotNull;
 import uk.firedev.daisylib.actions.ActionContext;
@@ -14,7 +15,7 @@ public class BreakActionType extends ActionType {
         return "break";
     }
 
-    @EventHandler
+    @EventHandler(priority = EventPriority.MONITOR)
     public void onBreakBlock(BlockBreakEvent event) {
         fire(ActionContext.create()
                 .withPlayer(event.getPlayer())

--- a/src/main/java/uk/firedev/daisylib/actions/types/BreakActionType.java
+++ b/src/main/java/uk/firedev/daisylib/actions/types/BreakActionType.java
@@ -17,6 +17,9 @@ public class BreakActionType extends ActionType {
 
     @EventHandler(priority = EventPriority.MONITOR)
     public void onBreakBlock(BlockBreakEvent event) {
+        if (event.isCancelled()) {
+            return;
+        }
         fire(ActionContext.create()
                 .withPlayer(event.getPlayer())
                 .withBlock(event.getBlock())

--- a/src/main/java/uk/firedev/daisylib/actions/types/BreedActionType.java
+++ b/src/main/java/uk/firedev/daisylib/actions/types/BreedActionType.java
@@ -1,0 +1,32 @@
+package uk.firedev.daisylib.actions.types;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.entity.EntityBreedEvent;
+import org.jetbrains.annotations.NotNull;
+import uk.firedev.daisylib.actions.ActionContext;
+import uk.firedev.daisylib.actions.ActionType;
+
+public class BreedActionType extends ActionType {
+
+    @NotNull
+    @Override
+    public String getActionIdentifier() {
+        return "breed";
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void onBreed(EntityBreedEvent event) {
+        if (event.isCancelled()) {
+            return;
+        }
+        if (!(event.getBreeder() instanceof Player player)) {
+            return;
+        }
+        fire(ActionContext.create()
+                .withPlayer(player)
+                .withAffectedEntity(event.getEntity())
+        );
+    }
+}

--- a/src/main/java/uk/firedev/daisylib/actions/types/BrushActionType.java
+++ b/src/main/java/uk/firedev/daisylib/actions/types/BrushActionType.java
@@ -1,0 +1,32 @@
+package uk.firedev.daisylib.actions.types;
+
+import org.bukkit.block.data.Brushable;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.block.BlockDropItemEvent;
+import org.jetbrains.annotations.NotNull;
+import uk.firedev.daisylib.actions.ActionContext;
+import uk.firedev.daisylib.actions.ActionType;
+
+public class BrushActionType extends ActionType {
+
+    @NotNull
+    @Override
+    public String getActionIdentifier() {
+        return "brush";
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void onBrush(BlockDropItemEvent event) {
+        if (event.isCancelled()) {
+            return;
+        }
+        if (!(event.getBlockState().getBlockData() instanceof Brushable)) {
+            return;
+        }
+        fire(ActionContext.create()
+                .withPlayer(event.getPlayer())
+                .withBlock(event.getBlock())
+        );
+    }
+}

--- a/src/main/java/uk/firedev/daisylib/actions/types/BucketEntityActionType.java
+++ b/src/main/java/uk/firedev/daisylib/actions/types/BucketEntityActionType.java
@@ -1,0 +1,29 @@
+package uk.firedev.daisylib.actions.types;
+
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.player.PlayerBucketEntityEvent;
+import org.jetbrains.annotations.NotNull;
+import uk.firedev.daisylib.actions.ActionContext;
+import uk.firedev.daisylib.actions.ActionType;
+
+public class BucketEntityActionType extends ActionType {
+
+    @NotNull
+    @Override
+    public String getActionIdentifier() {
+        return "bucket-entity";
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void onBucketEntity(PlayerBucketEntityEvent event) {
+        if (event.isCancelled()) {
+            return;
+        }
+        fire(ActionContext.create()
+                .withPlayer(event.getPlayer())
+                .withAffectedEntity(event.getEntity())
+        );
+    }
+
+}

--- a/src/main/java/uk/firedev/daisylib/actions/types/ConsumeActionType.java
+++ b/src/main/java/uk/firedev/daisylib/actions/types/ConsumeActionType.java
@@ -1,0 +1,29 @@
+package uk.firedev.daisylib.actions.types;
+
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.player.PlayerItemConsumeEvent;
+import org.jetbrains.annotations.NotNull;
+import uk.firedev.daisylib.actions.ActionContext;
+import uk.firedev.daisylib.actions.ActionType;
+
+public class ConsumeActionType extends ActionType {
+
+    @NotNull
+    @Override
+    public String getActionIdentifier() {
+        return "consume";
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void onConsume(PlayerItemConsumeEvent event) {
+        if (event.isCancelled()) {
+            return;
+        }
+        fire(ActionContext.create()
+                .withPlayer(event.getPlayer())
+                .withItem(event.getItem())
+        );
+    }
+
+}

--- a/src/main/java/uk/firedev/daisylib/actions/types/DyeActionType.java
+++ b/src/main/java/uk/firedev/daisylib/actions/types/DyeActionType.java
@@ -1,0 +1,30 @@
+package uk.firedev.daisylib.actions.types;
+
+import io.papermc.paper.event.entity.EntityDyeEvent;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.entity.SheepDyeWoolEvent;
+import org.jetbrains.annotations.NotNull;
+import uk.firedev.daisylib.actions.ActionContext;
+import uk.firedev.daisylib.actions.ActionType;
+
+public class DyeActionType extends ActionType {
+
+    @NotNull
+    @Override
+    public String getActionIdentifier() {
+        return "dye";
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void onDyeEntity(EntityDyeEvent event) {
+        if (event.isCancelled()) {
+            return;
+        }
+        fire(ActionContext.create()
+                .withPlayer(event.getPlayer())
+                .withAffectedEntity(event.getEntity())
+        );
+    }
+
+}

--- a/src/main/java/uk/firedev/daisylib/actions/types/EnchantActionType.java
+++ b/src/main/java/uk/firedev/daisylib/actions/types/EnchantActionType.java
@@ -1,0 +1,29 @@
+package uk.firedev.daisylib.actions.types;
+
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.enchantment.EnchantItemEvent;
+import org.jetbrains.annotations.NotNull;
+import uk.firedev.daisylib.actions.ActionContext;
+import uk.firedev.daisylib.actions.ActionType;
+
+public class EnchantActionType extends ActionType {
+
+    @NotNull
+    @Override
+    public String getActionIdentifier() {
+        return "enchant";
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void onEnchant(EnchantItemEvent event) {
+        if (event.isCancelled()) {
+            return;
+        }
+        fire(ActionContext.create()
+                .withPlayer(event.getEnchanter())
+                .withEnchantments(event.getEnchantsToAdd())
+                .withItem(event.getItem())
+        );
+    }
+}

--- a/src/main/java/uk/firedev/daisylib/actions/types/ExplodeActionType.java
+++ b/src/main/java/uk/firedev/daisylib/actions/types/ExplodeActionType.java
@@ -1,0 +1,45 @@
+package uk.firedev.daisylib.actions.types;
+
+import org.bukkit.entity.Creeper;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.TNTPrimed;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.entity.EntityExplodeEvent;
+import org.jetbrains.annotations.NotNull;
+import uk.firedev.daisylib.actions.ActionContext;
+import uk.firedev.daisylib.actions.ActionType;
+
+
+public class ExplodeActionType extends ActionType {
+
+    @NotNull
+    @Override
+    public String getActionIdentifier() {
+        return "explode";
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void onExplodeEntity(EntityExplodeEvent event) {
+        Entity entity = event.getEntity();
+        Entity source = null;
+
+        if (entity instanceof TNTPrimed tntPrimed) {
+            source = tntPrimed.getSource();
+        } else if (entity instanceof Creeper creeper) {
+            source = creeper.getIgniter();
+        }
+
+        if (!(source instanceof Player player)) {
+            return;
+        }
+
+        event.blockList().forEach(block -> fire(ActionContext.create()
+                .withPlayer(player)
+                .withBlock(block)
+                .withAffectedEntity(entity)
+        ));
+    }
+
+}

--- a/src/main/java/uk/firedev/daisylib/actions/types/ExplodeActionType.java
+++ b/src/main/java/uk/firedev/daisylib/actions/types/ExplodeActionType.java
@@ -22,6 +22,9 @@ public class ExplodeActionType extends ActionType {
 
     @EventHandler(priority = EventPriority.MONITOR)
     public void onExplodeEntity(EntityExplodeEvent event) {
+        if (event.isCancelled()) {
+            return;
+        }
         Entity entity = event.getEntity();
         Entity source = null;
 

--- a/src/main/java/uk/firedev/daisylib/actions/types/FishActionType.java
+++ b/src/main/java/uk/firedev/daisylib/actions/types/FishActionType.java
@@ -1,0 +1,34 @@
+package uk.firedev.daisylib.actions.types;
+
+import org.bukkit.entity.Item;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.player.PlayerFishEvent;
+import org.jetbrains.annotations.NotNull;
+import uk.firedev.daisylib.actions.ActionContext;
+import uk.firedev.daisylib.actions.ActionType;
+
+public class FishActionType extends ActionType {
+
+    @NotNull
+    @Override
+    public String getActionIdentifier() {
+        return "fish";
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void onFish(PlayerFishEvent event) {
+        if (event.isCancelled()) {
+            return;
+        }
+        if (event.getState() != PlayerFishEvent.State.CAUGHT_FISH || !(event.getCaught() instanceof Item item)) {
+            return;
+        }
+        fire(ActionContext.create()
+                .withPlayer(event.getPlayer())
+                .withAffectedEntity(item)
+                .withItem(item.getItemStack())
+        );
+    }
+
+}

--- a/src/main/java/uk/firedev/daisylib/actions/types/KillActionType.java
+++ b/src/main/java/uk/firedev/daisylib/actions/types/KillActionType.java
@@ -1,0 +1,34 @@
+package uk.firedev.daisylib.actions.types;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.entity.EntityDeathEvent;
+import org.jetbrains.annotations.NotNull;
+import uk.firedev.daisylib.actions.ActionContext;
+import uk.firedev.daisylib.actions.ActionType;
+
+public class KillActionType extends ActionType {
+
+        @NotNull
+        @Override
+        public String getActionIdentifier() {
+            return "kill";
+        }
+
+        @EventHandler(priority = EventPriority.MONITOR)
+        public void onEntityDeath(EntityDeathEvent event) {
+            if (event.isCancelled()) {
+                return;
+            }
+            Player killer = event.getEntity().getKiller();
+            if (killer == null) {
+                return;
+            }
+            fire(ActionContext.create()
+                    .withPlayer(killer)
+                    .withAffectedEntity(event.getEntity())
+            );
+        }
+
+}

--- a/src/main/java/uk/firedev/daisylib/actions/types/PlaceActionType.java
+++ b/src/main/java/uk/firedev/daisylib/actions/types/PlaceActionType.java
@@ -1,6 +1,7 @@
 package uk.firedev.daisylib.actions.types;
 
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.block.BlockPlaceEvent;
 import org.jetbrains.annotations.NotNull;
 import uk.firedev.daisylib.actions.ActionContext;
@@ -14,8 +15,11 @@ public class PlaceActionType extends ActionType {
         return "place";
     }
 
-    @EventHandler
+    @EventHandler(priority = EventPriority.MONITOR)
     public void onBlockPlaced(BlockPlaceEvent event) {
+        if (event.isCancelled()) {
+            return;
+        }
         fire(ActionContext.create()
                 .withPlayer(event.getPlayer())
                 .withBlock(event.getBlock())

--- a/src/main/java/uk/firedev/daisylib/actions/types/PlaceActionType.java
+++ b/src/main/java/uk/firedev/daisylib/actions/types/PlaceActionType.java
@@ -1,0 +1,25 @@
+package uk.firedev.daisylib.actions.types;
+
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.block.BlockPlaceEvent;
+import org.jetbrains.annotations.NotNull;
+import uk.firedev.daisylib.actions.ActionContext;
+import uk.firedev.daisylib.actions.ActionType;
+
+public class PlaceActionType extends ActionType {
+
+    @NotNull
+    @Override
+    public String getActionIdentifier() {
+        return "place";
+    }
+
+    @EventHandler
+    public void onBlockPlaced(BlockPlaceEvent event) {
+        fire(ActionContext.create()
+                .withPlayer(event.getPlayer())
+                .withBlock(event.getBlock())
+        );
+    }
+
+}

--- a/src/main/java/uk/firedev/daisylib/actions/types/ShearActionType.java
+++ b/src/main/java/uk/firedev/daisylib/actions/types/ShearActionType.java
@@ -1,0 +1,29 @@
+package uk.firedev.daisylib.actions.types;
+
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.player.PlayerShearEntityEvent;
+import org.jetbrains.annotations.NotNull;
+import uk.firedev.daisylib.actions.ActionContext;
+import uk.firedev.daisylib.actions.ActionType;
+
+public class ShearActionType extends ActionType {
+
+    @NotNull
+    @Override
+    public String getActionIdentifier() {
+        return "shear";
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void onShear(PlayerShearEntityEvent event) {
+        if (event.isCancelled()) {
+            return;
+        }
+        fire(ActionContext.create()
+                .withPlayer(event.getPlayer())
+                .withAffectedEntity(event.getEntity())
+        );
+    }
+
+}

--- a/src/main/java/uk/firedev/daisylib/actions/types/TameActionType.java
+++ b/src/main/java/uk/firedev/daisylib/actions/types/TameActionType.java
@@ -1,0 +1,33 @@
+package uk.firedev.daisylib.actions.types;
+
+import org.bukkit.entity.HumanEntity;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.entity.EntityTameEvent;
+import org.jetbrains.annotations.NotNull;
+import uk.firedev.daisylib.actions.ActionContext;
+import uk.firedev.daisylib.actions.ActionType;
+
+public class TameActionType extends ActionType {
+
+    @NotNull
+    @Override
+    public String getActionIdentifier() {
+        return "tame";
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void onTame(EntityTameEvent event) {
+        if (event.isCancelled()) {
+            return;
+        }
+        if (!(event.getOwner() instanceof Player player)) {
+            return;
+        }
+        fire(ActionContext.create()
+                .withPlayer(player)
+                .withAffectedEntity(event.getEntity())
+        );
+    }
+}

--- a/src/main/java/uk/firedev/daisylib/actions/types/TradeActionType.java
+++ b/src/main/java/uk/firedev/daisylib/actions/types/TradeActionType.java
@@ -1,0 +1,29 @@
+package uk.firedev.daisylib.actions.types;
+
+import io.papermc.paper.event.player.PlayerTradeEvent;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.jetbrains.annotations.NotNull;
+import uk.firedev.daisylib.actions.ActionContext;
+import uk.firedev.daisylib.actions.ActionType;
+
+public class TradeActionType extends ActionType {
+
+    @NotNull
+    @Override
+    public String getActionIdentifier() {
+        return "trade";
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void onTrade(PlayerTradeEvent event) {
+        if (event.isCancelled()) {
+            return;
+        }
+        fire(ActionContext.create()
+                .withPlayer(event.getPlayer())
+                .withAffectedEntity(event.getVillager())
+                .withItem(event.getTrade().getResult())
+        );
+    }
+}

--- a/src/main/java/uk/firedev/daisylib/actions/types/need-to-add.txt
+++ b/src/main/java/uk/firedev/daisylib/actions/types/need-to-add.txt
@@ -1,3 +1,5 @@
 CraftActionType - Missed because it needs more thought
 SmeltActionType - Requires a way to get a player from the furnace
 BrewActionType - Requires a way to get the player from the brewing stand
+MilkActionType - Do we even need this?
+ExploreActionType - Requires more code. Do we even need this?

--- a/src/main/java/uk/firedev/daisylib/actions/types/need-to-add.txt
+++ b/src/main/java/uk/firedev/daisylib/actions/types/need-to-add.txt
@@ -1,0 +1,3 @@
+CraftActionType - Missed because it needs more thought
+SmeltActionType - Requires a way to get a player from the furnace
+BrewActionType - Requires a way to get the player from the brewing stand

--- a/src/main/java/uk/firedev/daisylib/actions/types/need-to-add.txt
+++ b/src/main/java/uk/firedev/daisylib/actions/types/need-to-add.txt
@@ -3,3 +3,4 @@ SmeltActionType - Requires a way to get a player from the furnace
 BrewActionType - Requires a way to get the player from the brewing stand
 MilkActionType - Do we even need this?
 ExploreActionType - Requires more code. Do we even need this?
+CollectActionType - Requires more code. Do we even need this?

--- a/src/main/java/uk/firedev/daisylib/local/DaisyLib.java
+++ b/src/main/java/uk/firedev/daisylib/local/DaisyLib.java
@@ -7,6 +7,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.jetbrains.annotations.NotNull;
 import uk.firedev.daisylib.VaultManager;
+import uk.firedev.daisylib.actions.ActionManager;
 import uk.firedev.daisylib.events.DaisyLibReloadEvent;
 import uk.firedev.daisylib.local.command.LibCommand;
 import uk.firedev.daisylib.local.config.ExampleConfig;
@@ -62,6 +63,7 @@ public final class DaisyLib extends JavaPlugin {
         VaultManager.getInstance().load();
         RewardManager.getInstance().load();
         RequirementManager.getInstance().load();
+        ActionManager.getInstance().load();
     }
 
     public static DaisyLib getInstance() { return instance; }


### PR DESCRIPTION
Adds the guts of an action system.

- Adds ActionManager for action-related things.
- Adds ActionContext for use when actions are fired.
- Adds ActionType abstract class to name and fire actions.
- Adds ActionListener abstract class to run code when an action is fired.

Added ActionTypes:
- Break
- Explode
- Place
- Kill
- Fish
- Trade
- Enchant
- Breed
- Tame
- Dye
- Shear
- Consume
- BucketEntity
- Brush