### PR TITLE
Adds an Addon system

### DIFF
--- a/daisylib-api/src/main/java/uk/firedev/daisylib/api/addons/Addon.java
+++ b/daisylib-api/src/main/java/uk/firedev/daisylib/api/addons/Addon.java
@@ -1,0 +1,14 @@
+package uk.firedev.daisylib.api.addons;
+
+import org.bukkit.plugin.Plugin;
+import org.jetbrains.annotations.NotNull;
+
+public interface Addon {
+
+    @NotNull String getIdentifier();
+
+    @NotNull Plugin getOwningPlugin();
+
+    @NotNull String getAuthor();
+
+}

--- a/daisylib-api/src/main/java/uk/firedev/daisylib/api/addons/ItemAddon.java
+++ b/daisylib-api/src/main/java/uk/firedev/daisylib/api/addons/ItemAddon.java
@@ -1,0 +1,63 @@
+package uk.firedev.daisylib.api.addons;
+
+import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import uk.firedev.daisylib.api.Loggers;
+import uk.firedev.daisylib.api.addons.exceptions.InvalidAddonException;
+import uk.firedev.daisylib.api.addons.exceptions.InvalidItemException;
+
+import java.util.TreeMap;
+
+public abstract class ItemAddon implements Addon {
+
+    private static final TreeMap<String, ItemAddon> loadedAddons = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+
+    public static @Nullable ItemAddon get(@NotNull String identifier) {
+        return loadedAddons.get(identifier);
+    }
+
+    public static boolean unregister(@NotNull String identifier) {
+        if (!loadedAddons.containsKey(identifier)) {
+            return false;
+        }
+        loadedAddons.remove(identifier);
+        return true;
+    }
+
+    public static @Nullable ItemStack processString(@NotNull String string) {
+        String[] split = string.split("=");
+        String name;
+        String itemId;
+        try {
+            name = split[0];
+            itemId = split[1];
+        } catch (ArrayIndexOutOfBoundsException exception) {
+            Loggers.warn(ItemAddon.class, "Failed to process an ItemAddon String! \"" + string + "\" is not formatted correctly.", new InvalidItemException());
+            return null;
+        }
+        ItemAddon addon = get(name);
+        if (addon == null) {
+            Loggers.warn(ItemAddon.class, "Failed to process an ItemAddon String! \"" + name + "\" is not a valid ItemAddon.", new InvalidAddonException());
+            return null;
+        }
+        return addon.getItem(itemId);
+    }
+
+    public ItemAddon() {}
+
+    public abstract ItemStack getItem(@NotNull String id);
+
+    public boolean register() {
+        if (loadedAddons.containsKey(getIdentifier())) {
+            return false;
+        }
+        loadedAddons.put(getIdentifier(), this);
+        return true;
+    }
+
+    public boolean unregister() {
+        return unregister(getIdentifier());
+    }
+
+}

--- a/daisylib-api/src/main/java/uk/firedev/daisylib/api/addons/ItemAddon.java
+++ b/daisylib-api/src/main/java/uk/firedev/daisylib/api/addons/ItemAddon.java
@@ -25,7 +25,10 @@ public abstract class ItemAddon implements Addon {
         return true;
     }
 
-    public static @Nullable ItemStack processString(@NotNull String string) {
+    public static @Nullable ItemStack processString(@Nullable String string) {
+        if (string == null) {
+            return null;
+        }
         String[] split = string.split("=");
         String name;
         String itemId;

--- a/daisylib-api/src/main/java/uk/firedev/daisylib/api/addons/ItemAddon.java
+++ b/daisylib-api/src/main/java/uk/firedev/daisylib/api/addons/ItemAddon.java
@@ -60,4 +60,20 @@ public abstract class ItemAddon implements Addon {
         return unregister(getIdentifier());
     }
 
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof ItemAddon addon)) {
+            return false;
+        }
+        return getIdentifier().equals(addon.getIdentifier());
+    }
+
+    @Override
+    public int hashCode() {
+        return getIdentifier().hashCode();
+    }
+
 }

--- a/daisylib-api/src/main/java/uk/firedev/daisylib/api/addons/exceptions/InvalidAddonException.java
+++ b/daisylib-api/src/main/java/uk/firedev/daisylib/api/addons/exceptions/InvalidAddonException.java
@@ -1,0 +1,17 @@
+package uk.firedev.daisylib.api.addons.exceptions;
+
+public class InvalidAddonException extends RuntimeException {
+
+    public InvalidAddonException() {
+        super();
+    }
+
+    public InvalidAddonException(String message) {
+        super(message);
+    }
+
+    public InvalidAddonException(Throwable throwable) {
+        super(throwable);
+    }
+
+}

--- a/daisylib-api/src/main/java/uk/firedev/daisylib/api/addons/exceptions/InvalidItemException.java
+++ b/daisylib-api/src/main/java/uk/firedev/daisylib/api/addons/exceptions/InvalidItemException.java
@@ -1,0 +1,17 @@
+package uk.firedev.daisylib.api.addons.exceptions;
+
+public class InvalidItemException extends RuntimeException {
+
+    public InvalidItemException() {
+        super();
+    }
+
+    public InvalidItemException(String message) {
+        super(message);
+    }
+
+    public InvalidItemException(Throwable throwable) {
+        super(throwable);
+    }
+
+}

--- a/daisylib-api/src/main/java/uk/firedev/daisylib/api/builders/ItemBuilder.java
+++ b/daisylib-api/src/main/java/uk/firedev/daisylib/api/builders/ItemBuilder.java
@@ -254,15 +254,14 @@ public class ItemBuilder {
         return this.item.clone();
     }
 
-    // TODO support for external plugin items
-    public ItemBuilder loadConfig(@Nullable ConfigurationSection section, @Nullable ComponentReplacer displayReplacer, @Nullable ComponentReplacer loreReplacer) {
+    private ItemBuilder loadConfig(@Nullable ConfigurationSection section, @Nullable ComponentReplacer displayReplacer, @Nullable ComponentReplacer loreReplacer) {
         if (section == null) {
             return this;
         }
 
-        Material material = ItemUtils.getMaterial(section.getString("material"));
-        if (material != null) {
-            withMaterial(material);
+        ItemStack item = ItemUtils.getItem(section.getString("material"));
+        if (item != null) {
+            this.item = item;
         }
 
         String display = section.getString("display");

--- a/daisylib-api/src/main/java/uk/firedev/daisylib/api/utils/ItemUtils.java
+++ b/daisylib-api/src/main/java/uk/firedev/daisylib/api/utils/ItemUtils.java
@@ -13,6 +13,7 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.SkullMeta;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import uk.firedev.daisylib.api.addons.ItemAddon;
 import uk.firedev.daisylib.api.message.component.ComponentMessage;
 
 import java.util.Arrays;
@@ -22,12 +23,17 @@ import java.util.UUID;
 
 public class ItemUtils {
 
-    public static @NotNull Material getMaterial(@Nullable String materialName, @NotNull Material defaultMaterial) {
-        Material material = getMaterial(materialName);
-        if (material == null) {
-            return defaultMaterial;
+    public static @Nullable ItemStack getItem(@Nullable String itemName) {
+        Material material = getMaterial(itemName);
+        if (material != null) {
+            return ItemStack.of(material);
         }
-        return material;
+        return ItemAddon.processString(itemName);
+    }
+
+    public static @NotNull ItemStack getItem(@Nullable String itemName, @NotNull ItemStack defaultItem) {
+        ItemStack item = getItem(itemName);
+        return item == null ? defaultItem : item;
     }
 
     public static @Nullable Material getMaterial(@Nullable String materialName) {
@@ -35,6 +41,14 @@ public class ItemUtils {
             return null;
         }
         return ObjectUtils.getEnumValue(Material.class, materialName);
+    }
+
+    public static @NotNull Material getMaterial(@Nullable String materialName, @NotNull Material defaultMaterial) {
+        Material material = getMaterial(materialName);
+        if (material == null) {
+            return defaultMaterial;
+        }
+        return material;
     }
 
     public static boolean validMaterial(@Nullable String materialName) {

--- a/daisylib-plugin/build.gradle.kts
+++ b/daisylib-plugin/build.gradle.kts
@@ -21,6 +21,7 @@ repositories {
     maven("https://repo.md5lukas.de/public")
 
     // ItemAddons
+    maven("https://maven.citizensnpcs.co/repo")
     maven("https://repo.nexomc.com/releases")
 }
 
@@ -35,6 +36,9 @@ dependencies {
     compileOnly(libs.miniplaceholders)
 
     // ItemAddons
+    compileOnly(libs.denizen) {
+        exclude("*", "*")
+    }
     compileOnly(libs.nexo)
 
     implementation(libs.triumphgui)

--- a/daisylib-plugin/build.gradle.kts
+++ b/daisylib-plugin/build.gradle.kts
@@ -19,6 +19,9 @@ repositories {
     maven("https://repo.minebench.de/")
     maven("https://repo.codemc.io/repository/maven-snapshots/")
     maven("https://repo.md5lukas.de/public")
+
+    // ItemAddons
+    maven("https://repo.nexomc.com/releases")
 }
 
 dependencies {
@@ -30,6 +33,9 @@ dependencies {
         exclude("*", "*")
     }
     compileOnly(libs.miniplaceholders)
+
+    // ItemAddons
+    compileOnly(libs.nexo)
 
     implementation(libs.triumphgui)
     implementation(libs.anvilgui)

--- a/daisylib-plugin/src/main/java/uk/firedev/daisylib/addons/items/DenizenItemAddon.java
+++ b/daisylib-plugin/src/main/java/uk/firedev/daisylib/addons/items/DenizenItemAddon.java
@@ -1,0 +1,35 @@
+package uk.firedev.daisylib.addons.items;
+
+import com.denizenscript.denizen.objects.ItemTag;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.plugin.Plugin;
+import org.jetbrains.annotations.NotNull;
+import uk.firedev.daisylib.api.addons.ItemAddon;
+import uk.firedev.daisylib.local.DaisyLib;
+
+public class DenizenItemAddon extends ItemAddon {
+
+    @Override
+    public ItemStack getItem(@NotNull String id) {
+        ItemTag item = ItemTag.valueOf(id, false);
+        return item == null ? null : item.getItemStack();
+    }
+
+    @NotNull
+    @Override
+    public String getIdentifier() {
+        return "Denizen";
+    }
+
+    @Override
+    public @NotNull Plugin getOwningPlugin() {
+        return DaisyLib.getInstance();
+    }
+
+    @NotNull
+    @Override
+    public String getAuthor() {
+        return "FireML";
+    }
+
+}

--- a/daisylib-plugin/src/main/java/uk/firedev/daisylib/addons/items/NexoItemAddon.java
+++ b/daisylib-plugin/src/main/java/uk/firedev/daisylib/addons/items/NexoItemAddon.java
@@ -1,0 +1,36 @@
+package uk.firedev.daisylib.addons.items;
+
+import com.nexomc.nexo.api.NexoItems;
+import com.nexomc.nexo.items.ItemBuilder;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.plugin.Plugin;
+import org.jetbrains.annotations.NotNull;
+import uk.firedev.daisylib.api.addons.ItemAddon;
+import uk.firedev.daisylib.local.DaisyLib;
+
+public class NexoItemAddon extends ItemAddon {
+
+    @Override
+    public ItemStack getItem(@NotNull String id) {
+        ItemBuilder item = NexoItems.itemFromId(id);
+        return item == null ? null : item.build();
+    }
+
+    @NotNull
+    @Override
+    public String getIdentifier() {
+        return "Nexo";
+    }
+
+    @Override
+    public @NotNull Plugin getOwningPlugin() {
+        return DaisyLib.getInstance();
+    }
+
+    @NotNull
+    @Override
+    public String getAuthor() {
+        return "FireML";
+    }
+
+}

--- a/daisylib-plugin/src/main/java/uk/firedev/daisylib/local/DaisyLib.java
+++ b/daisylib-plugin/src/main/java/uk/firedev/daisylib/local/DaisyLib.java
@@ -26,7 +26,6 @@ public final class DaisyLib extends JavaPlugin {
     public void onLoad() {
         CommandAPI.onLoad(new CommandAPIBukkitConfig(this)
                 .shouldHookPaperReload(true)
-                .usePluginNamespace()
                 .missingExecutorImplementationMessage("You are not able to use this command!")
         );
     }

--- a/daisylib-plugin/src/main/java/uk/firedev/daisylib/local/DaisyLib.java
+++ b/daisylib-plugin/src/main/java/uk/firedev/daisylib/local/DaisyLib.java
@@ -6,6 +6,7 @@ import org.bstats.bukkit.Metrics;
 import org.bukkit.Bukkit;
 import org.bukkit.plugin.java.JavaPlugin;
 import uk.firedev.daisylib.VaultManager;
+import uk.firedev.daisylib.addons.items.NexoItemAddon;
 import uk.firedev.daisylib.events.CustomEventListener;
 import uk.firedev.daisylib.events.DaisyLibReloadEvent;
 import uk.firedev.daisylib.local.command.LibCommand;
@@ -38,6 +39,7 @@ public final class DaisyLib extends JavaPlugin {
         LibCommand.getCommand().register();
         getServer().getPluginManager().registerEvents(new CustomEventListener(), this);
         loadManagers();
+        loadAddons();
         loadMetrics();
     }
 
@@ -60,6 +62,10 @@ public final class DaisyLib extends JavaPlugin {
         VaultManager.getInstance().load();
         RewardManager.getInstance().load();
         RequirementManager.getInstance().load();
+    }
+
+    private void loadAddons() {
+        new NexoItemAddon().register();
     }
 
     public static DaisyLib getInstance() { return instance; }

--- a/daisylib-plugin/src/main/java/uk/firedev/daisylib/local/DaisyLib.java
+++ b/daisylib-plugin/src/main/java/uk/firedev/daisylib/local/DaisyLib.java
@@ -6,6 +6,7 @@ import org.bstats.bukkit.Metrics;
 import org.bukkit.Bukkit;
 import org.bukkit.plugin.java.JavaPlugin;
 import uk.firedev.daisylib.VaultManager;
+import uk.firedev.daisylib.addons.items.DenizenItemAddon;
 import uk.firedev.daisylib.addons.items.NexoItemAddon;
 import uk.firedev.daisylib.events.CustomEventListener;
 import uk.firedev.daisylib.events.DaisyLibReloadEvent;
@@ -66,6 +67,7 @@ public final class DaisyLib extends JavaPlugin {
 
     private void loadAddons() {
         new NexoItemAddon().register();
+        new DenizenItemAddon().register();
     }
 
     public static DaisyLib getInstance() { return instance; }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-project-version=2.3.0-SNAPSHOT
+project-version=2.3.1-SNAPSHOT

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -13,6 +13,7 @@ dependencyResolutionManagement {
             library("placeholderapi", "me.clip:placeholderapi:2.11.6")
             library("vault", "com.github.MilkBowl:VaultAPI:1.7")
             library("miniplaceholders", "io.github.miniplaceholders:miniplaceholders-api:2.2.3")
+            library("nexo", "com.nexomc:nexo:0.7.0")
 
             // implementation dependencies
             library("triumphgui", "dev.triumphteam:triumph-gui:3.1.11")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -14,6 +14,7 @@ dependencyResolutionManagement {
             library("vault", "com.github.MilkBowl:VaultAPI:1.7")
             library("miniplaceholders", "io.github.miniplaceholders:miniplaceholders-api:2.2.3")
             library("nexo", "com.nexomc:nexo:0.7.0")
+            library("denizen", "com.denizenscript:denizen:1.3.1-SNAPSHOT")
 
             // implementation dependencies
             library("triumphgui", "dev.triumphteam:triumph-gui:3.1.11")


### PR DESCRIPTION
Currently this only consists of ItemAddons, but more can be added as needed.

Changes:
- Added Addon interface
- Added ItemAddon abstract class
- Added NexoItemAddon
- Added DenizenItemAddon
- ItemBuilder#createWithConfig now supports these new ItemAddons:
```
  example:
    item:
      material: denizen=test_item
```
- Bumped the plugin's version to 2.3.1-SNAPSHOT